### PR TITLE
Fix: Correct partial paths for Hugo v0.55+ compatibility

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
               <h2 class="font-medium text-gray-700 text-xl relative z-10">{{ .Title }}</h2>
             </a>
           </div>
-          {{ partial "partials/posts/meta.html" . }}
+          {{ partial "posts/meta.html" . }}
           <div class="post-card">
             {{ .Summary | safeHTML }}
             <div class="block text-right mt-4 font-light text-lg">
@@ -28,6 +28,6 @@
         </div>
       {{ end }}
     </div>
-    {{ partial "partials/pagination.html" . }}
+    {{ partial "pagination.html" . }}
   </div>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -8,7 +8,7 @@
           alt="{{ .Title }}"
           title="{{ .Title }}" />
         <h1 class="font-medium text-gray-700 text-3xl md:text-4xl mb-5">{{ .Title }}</h1>
-        {{ partial "partials/posts/meta.html" . }}
+        {{ partial "posts/meta.html" . }}
 
         {{ .Content | safeHTML }}
       </div>


### PR DESCRIPTION
`{{ partial "partials/xxx" . }}` This format cannot be correctly processed by the new version of Hugo. The `partials/` prefix needs to be removed.